### PR TITLE
[IUM-3882] Added maxHeaderSize to server initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ var freeport = require('freeport');
 var kerberos_proxy = require('./kerberos_proxy');
 
 function KerberosServer(handler, options) {
-  Server.call(this, handler);
+  // In case maxHeaderSize is not defined we can use the default
+  const maxHeaderSize = options?.maxHeaderSize ?? 16834;
+
+  Server.call(this, { maxHeaderSize }, handler);
   this._options = options || {};
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kerberos-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Kerberos http server interface",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kerberos-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Kerberos http server interface",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.

We aren't passing down options from https://github.com/auth0/ad-ldap-connector/blob/master/server.js#L131 to https://github.com/auth0/node-kerberos-server/blob/master/index.js#L7 so maxHeaderSize always ends up as the default of Node.js header size of 16kb.

<img width="1200" height="600" alt="Code_Generated_Image" src="https://github.com/user-attachments/assets/78252347-2d4e-4ae2-854f-d1081cfbe167" />

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

JIRA ticket: https://auth0team.atlassian.net/browse/IUM-3882
Video demo of problem and solution being implemented: https://drive.google.com/file/d/1aeAid9IDXo2endHH_bfjody2hu-qD4mU/view?usp=sharing
How to guide to setup OpenLDAP on a local windows machine: https://oktawiki.atlassian.net/wiki/spaces/USER/pages/4321247405/How+to+configure+and+use+AD+LDAP+connector+in+a+local+Windows+Machine

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

This change can be tested by following along the testing linked in the video demo along with a how to guide on setting up OpenLdap on a local windows machine for running these tests.

Additionally, if someone is looking to test the http initialization directly as this is the only portion changing, they can comment out the Kerberos related code and npm link this repo to the `ad-ldap-connector` while also forcing these lines to run https://github.com/auth0/ad-ldap-connector/blob/master/server.js#L126-L136, This way you can test these changes against vivaldi and a mac environment while following this guide https://oktawiki.atlassian.net/wiki/spaces/PCX/pages/2537331965/How+to+configure+and+use+AD+LDAP+connector+in+Vivaldi

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
